### PR TITLE
Enable installation on Debian systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Beta Release: Wrapper around fast C native realpath. Low startup time makes this great for build scripts.",
   "main": "index.js",
   "scripts": {
-    "postinstall": "gcc -o ./.bin/realpath -x c - <<< $'#include<stdlib.h>\nmain(int cc, char**vargs){\n  puts(realpath(vargs[1], 0));\n}'",
+    "postinstall": "gcc -o ./.bin/realpath -x c ./realpath.c",
     "test": "echo \"No test\""
   },
   "repository": {

--- a/realpath.c
+++ b/realpath.c
@@ -1,0 +1,6 @@
+#include<stdlib.h>
+
+main(int cc, char**vargs) {
+  puts(realpath(vargs[1], 0));
+}
+


### PR DESCRIPTION
`/bin/sh` on Debian systems is Dash (not Bash), and does not support the `<<<`
redirection operator.